### PR TITLE
Fix installation error on PostgreSQL 9.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ all: sql/$(EXTENSION)--$(EXTVERSION).sql
 sql/$(EXTENSION)--$(EXTVERSION).sql: sql/$(EXTENSION).sql
 	cp $< $@
 
-DATA = $(wildcard sql/*--*.sql) sql/$(EXTENSION)--$(EXTVERSION).sql
+DATA = $(wildcard sql/*--*.sql)
 EXTRA_CLEAN = sql/$(EXTENSION)--$(EXTVERSION).sql
 endif
 


### PR DESCRIPTION
The duplicate term in $DATA causes installation error on 9.3. (No problem with 9.2)

```
$ make install
/bin/mkdir -p '/db/postgres/share/extension'
/bin/mkdir -p '/db/postgres/share/extension'
/bin/mkdir -p '/db/postgres/lib'
/bin/mkdir -p '/db/postgres/share/doc/extension'
/usr/bin/install -c -m 644 ./pg_proctab.control '/db/postgres/share/extension/'
/usr/bin/install -c -m 644 ./sql/pg_proctab--0.0.5.sql ./sql/pg_proctab--0.0.5.sql  '/db/postgres/share/extension/'
/usr/bin/install: will not overwrite just-created `/db/postgres/share/extension/pg_proctab--0.0.5.sql' with `./sql/pg_proctab--0.0.5.sql'
make: *** [install] Error 1
```

This commit fixes the problem.

```
$ make install
/bin/mkdir -p '/db/postgres/share/extension'
/bin/mkdir -p '/db/postgres/share/extension'
/bin/mkdir -p '/db/postgres/lib'
/bin/mkdir -p '/db/postgres/share/doc/extension'
/usr/bin/install -c -m 644 ./pg_proctab.control '/db/postgres/share/extension/'
/usr/bin/install -c -m 644 ./sql/pg_proctab--0.0.5.sql  '/db/postgres/share/extension/'
/usr/bin/install -c -m 755  src/pg_proctab.so '/db/postgres/lib/'
/usr/bin/install -c -m 644 ./doc/PORTING ./doc/README '/db/postgres/share/doc/extension/'
```

See:
- http://www.postgresql.org/message-id/CABRT9RASFgGqP-DJv0EAyXeFnquuap1-P=PVma=ZtnKHiNWPpA@mail.gmail.com
- http://www.postgresql.org/message-id/1368498422.420.9.camel@vanquo.pezone.net
