### PR TITLE
Conditional compilation with __FreeBSD__ macro

### DIFF
--- a/src/pg_proctab.c
+++ b/src/pg_proctab.c
@@ -11,7 +11,11 @@
 #include "utils/tuplestore.h"
 #include "storage/fd.h"
 #include "utils/builtins.h"
-#include <sys/vfs.h>
+#ifndef __FreeBSD__
+  #include <sys/vfs.h>
+#else
+  #include <sys/mount.h>
+#endif
 #include <unistd.h>
 #include <sys/stat.h>
 #include <fcntl.h>


### PR DESCRIPTION
Simple include switch in order to make the extension compile on FreeBSD.