### PR TITLE
fix undefined type error, undefined type ‘struct passwd’

### DIFF
--- a/src/pg_proctab.c
+++ b/src/pg_proctab.c
@@ -21,6 +21,7 @@
 #include <fcntl.h>
 #include <sys/param.h>
 #include <executor/spi.h>
+#include <pwd.h>
 #include "pg_proctab.h"
 
 #define FULLCOMM_LEN 1024


### PR DESCRIPTION
2.754 src/pg_proctab.c:333:73: error: invalid use of undefined type ‘struct passwd’
2.754   333 |                         values[i_username] = (char *) palloc((strlen(pwd->pw_name) +
2.754       |                                                                         ^~
2.756 src/pg_proctab.c:335:55: error: invalid use of undefined type ‘struct passwd’
2.756   335 |                         strcpy(values[i_username], pwd->pw_name);
2.756       |                                                       ^~
2.919 make: *** [<builtin>: src/pg_proctab.o] Error 1